### PR TITLE
Update source path for homebrew asdf

### DIFF
--- a/mac
+++ b/mac
@@ -128,7 +128,7 @@ add_or_update_asdf_plugin() {
 }
 
 # shellcheck disable=SC1090
-source "$HOME/.asdf/asdf.sh"
+source "$(brew --prefix asdf)/libexec/asdf.sh"
 add_or_update_asdf_plugin "nodejs" "https://github.com/asdf-vm/asdf-nodejs.git"
 add_or_update_asdf_plugin "golang" "https://github.com/kennyp/asdf-golang.git"
 add_or_update_asdf_plugin "java" "https://github.com/halcyon/asdf-java.git"


### PR DESCRIPTION
While trying to configure asdf installed via homebrew, the given source did not work.

Error:
```
mac: line 131: /Users/bianca.lisle/.asdf/asdf.sh: No such file or directory
```

The issue was fixed by retrieving the right path through brew --prefix.

Sources:
- https://asdf-vm.com/guide/getting-started.html#_3-install-asdf
- https://github.com/asdf-vm/asdf/issues/785
